### PR TITLE
VP-1638: Chained Stackable policy discounts

### DIFF
--- a/VirtoCommerce.MarketingModule.Data/Services/DefaultPromotionRewardEvaluator.cs
+++ b/VirtoCommerce.MarketingModule.Data/Services/DefaultPromotionRewardEvaluator.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using VirtoCommerce.Domain.Common;
+using VirtoCommerce.Domain.Marketing.Model;
+
+namespace VirtoCommerce.MarketingModule.Data.Services
+{
+    public class DefaultPromotionRewardEvaluator : IPromotionRewardEvaluator
+    {
+        public virtual IEnumerable<PromotionReward> GetOrderedValidRewards(IEnumerable<Promotion> promotions, IEvaluationContext context)
+        {
+            var result = promotions.SelectMany(x => x.EvaluatePromotion(context))
+                        .OrderByDescending(x => x.Promotion.IsExclusive)
+                        .ThenByDescending(x => x.Promotion.Priority)
+                        .Where(x => x.IsValid)
+                        .ToList();
+
+            return result;
+        }
+    }
+}

--- a/VirtoCommerce.MarketingModule.Data/Services/IPromotionRewardEvaluator.cs
+++ b/VirtoCommerce.MarketingModule.Data/Services/IPromotionRewardEvaluator.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using VirtoCommerce.Domain.Common;
+using VirtoCommerce.Domain.Marketing.Model;
+
+namespace VirtoCommerce.MarketingModule.Data.Services
+{
+    public interface IPromotionRewardEvaluator
+    {
+        IEnumerable<PromotionReward> GetOrderedValidRewards(IEnumerable<Promotion> promotions, IEvaluationContext context);
+    }
+}

--- a/VirtoCommerce.MarketingModule.Data/VirtoCommerce.MarketingModule.Data.csproj
+++ b/VirtoCommerce.MarketingModule.Data/VirtoCommerce.MarketingModule.Data.csproj
@@ -135,9 +135,11 @@
     <Compile Include="Repositories\MarketingRepositoryImpl.cs" />
     <Compile Include="Services\CouponService.cs" />
     <Compile Include="Services\DefaultDynamicContentEvaluatorImpl.cs" />
+    <Compile Include="Services\DefaultPromotionRewardEvaluator.cs" />
     <Compile Include="Services\DynamicContentServiceImpl.cs" />
     <Compile Include="Services\EvaluationPolicies\BestRewardPromotionPolicy.cs" />
     <Compile Include="Services\EvaluationPolicies\CombineStackablePromotionPolicy.cs" />
+    <Compile Include="Services\IPromotionRewardEvaluator.cs" />
     <Compile Include="Services\MarketingSearchServiceImpl.cs" />
     <Compile Include="Services\PromotionUsageService.cs" />
     <Compile Include="Services\PromotionServiceImpl.cs" />

--- a/VirtoCommerce.MarketingModule.Test/CombineStackablePromotionPolicyTest.cs
+++ b/VirtoCommerce.MarketingModule.Test/CombineStackablePromotionPolicyTest.cs
@@ -322,7 +322,7 @@ namespace VirtoCommerce.MarketingModule.Test
                     {
                        new CatalogItemAmountReward { ProductId = "ProductA", Amount = 20, AmountType = RewardAmountType.Relative, IsValid = true }
                     },
-                    Priority = 0,
+                    Priority = 10,
                     IsExclusive = false
                 };
                 yield return new MockPromotion
@@ -333,7 +333,7 @@ namespace VirtoCommerce.MarketingModule.Test
                     {
                         new ShipmentReward { ShippingMethod = "FedEx", Amount = 100, AmountType = RewardAmountType.Relative, IsValid = true  }
                     },
-                    Priority = 0,
+                    Priority = 2,
                     IsExclusive = false
                 };
                 yield return new MockPromotion

--- a/VirtoCommerce.MarketingModule.Web/Module.cs
+++ b/VirtoCommerce.MarketingModule.Web/Module.cs
@@ -1,7 +1,7 @@
+using Microsoft.Practices.Unity;
 using System;
 using System.Linq;
 using System.Web.Http;
-using Microsoft.Practices.Unity;
 using VirtoCommerce.Domain.Marketing.Services;
 using VirtoCommerce.Domain.Order.Events;
 using VirtoCommerce.MarketingModule.Data.ExportImport;
@@ -58,6 +58,7 @@ namespace VirtoCommerce.MarketingModule.Web
             _container.RegisterType<IPromotionUsageService, PromotionUsageService>();
             _container.RegisterType<IMarketingDynamicContentEvaluator, DefaultDynamicContentEvaluatorImpl>();
             _container.RegisterType<IDynamicContentService, DynamicContentServiceImpl>();
+            _container.RegisterType<IPromotionRewardEvaluator, DefaultPromotionRewardEvaluator>();
 
             _container.RegisterType<IPromotionSearchService, MarketingSearchServiceImpl>();
             _container.RegisterType<ICouponService, CouponService>();


### PR DESCRIPTION
- After applying reward that could affect discount on cart total remaining discount conditions are re-evaluated;
- Shipment rewards are applied after items and subtotal rewards now to allow shipment promotion use discounted cart subtotal in conditions;
- Added test for applying rewards with the same priority;