### PR TITLE
VP-1842: Support payment method rewards

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Web/Model/PromotionReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Model/PromotionReward.cs
@@ -104,6 +104,12 @@ namespace VirtoCommerce.MarketingModule.Web.Model
         /// Gets or sets the value of reward shipping method code
         /// </summary>
         public string ShippingMethod { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of reward payment method code
+        /// </summary>
+        public string PaymentMethod { get; set; }
+
         /// <summary>
         /// Gets or sets the max limit for relative rewards
         /// </summary>

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
@@ -15,12 +15,12 @@ angular.module('virtoCommerce.marketingModule')
             $scope.stores = stores.query({}, function(data) {
                 _.each(data, function(store) {
                     var storeId = store.id;
-                    shippingMethods.search({ storeId }, function (data) {
-                        store.shippingMethods = _.findWhere(data.results, { isActive: true });
+                    shippingMethods.search({ storeId }, function (shippingMethodsData) {
+                        store.shippingMethods = _.findWhere(shippingMethodsData.results, { isActive: true }) || [];
                     });
 
-                    paymentMethods.search({ storeId }, function (data) {
-                        store.paymentMethods = _.findWhere(data.results, { isActive: true });
+                    paymentMethods.search({ storeId }, function (paymentMethodsData) {
+                        store.paymentMethods = _.findWhere(paymentMethodsData.results, { isActive: true }) || [];
                     });
                 })
 

--- a/tests/VirtoCommerce.MarketingModule.Test/CustomReward/NonHandledReward.cs
+++ b/tests/VirtoCommerce.MarketingModule.Test/CustomReward/NonHandledReward.cs
@@ -1,0 +1,8 @@
+using VirtoCommerce.MarketingModule.Core.Model.Promotions;
+
+namespace VirtoCommerce.MarketingModule.Test.CustomReward
+{
+    public class NonHandledReward : PromotionReward
+    {
+    }
+}


### PR DESCRIPTION
- Supported PaymentReward's;
- Exception is thrown in case of unsupported rewards to eliminated risk of infinite cycling;
- Added tests for PaymentReward's appliance and unsupported rewards;
- Fixed bug with the JS exception if click "Select payment method reward" in payment reward, if promotion is set for the store with no active payment methods;