### PR TITLE
VP-1845: Fill RewardType in EvaluatePromotions API

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/AmountBasedReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/AmountBasedReward.cs
@@ -5,7 +5,10 @@ using VirtoCommerce.CoreModule.Core.Extensions;
 namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
 {
     public abstract class AmountBasedReward : PromotionReward
-    {        
+    {
+        protected AmountBasedReward(string rewardType) : base(rewardType)
+        { }
+
         public RewardAmountType AmountType { get; set; }
         /// <summary>
         /// Reward amount

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/CartRewards/CartSubtotalReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/CartRewards/CartSubtotalReward.cs
@@ -2,5 +2,7 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
 {
     public class CartSubtotalReward : AmountBasedReward
     {
+        public CartSubtotalReward() : base(nameof(CartSubtotalReward))
+        { }
     }
 }

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/GiftReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/GiftReward.cs
@@ -5,6 +5,8 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
     /// </summary>
     public class GiftReward : PromotionReward
     {
+        public GiftReward() : base(nameof(GiftReward))
+        { }
         public string Name { get; set; }
 
         public string CategoryId { get; set; }

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/ItemRewards/CatalogItemAmountReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/ItemRewards/CatalogItemAmountReward.cs
@@ -2,7 +2,9 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
 {
     public class CatalogItemAmountReward : AmountBasedReward
     {
-       
+        public CatalogItemAmountReward() : base(nameof(CatalogItemAmountReward))
+        { }
+
         /// <summary>
         /// Target reward product
         /// </summary>

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/PaymentRewards/PaymentReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/PaymentRewards/PaymentReward.cs
@@ -5,6 +5,9 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
     /// </summary>
     public class PaymentReward : AmountBasedReward
     {
+        public PaymentReward() : base(nameof(PaymentReward))
+        { }
+
         public string PaymentMethod { get; set; }
     }
 }

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/PromotionReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/PromotionReward.cs
@@ -6,7 +6,7 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
     {
         protected PromotionReward()
         {
-            Id = GetType().Name;
+            RewardType = Id = GetType().Name;
         }
 
         public string Id { get; set; }
@@ -40,6 +40,6 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
         /// <summary>
         /// Promotion reward type. Should be here for proper web model PromotionReward.RewardType filling
         /// </summary>
-        public string RewardType => GetType().Name;
+        public string RewardType { get; set; }
     }
 }

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/PromotionReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/PromotionReward.cs
@@ -8,7 +8,7 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
         {
             Id = GetType().Name;
         }
-       
+
         public string Id { get; set; }
         /// <summary>
         /// Flag for applicability
@@ -37,5 +37,9 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
 
         public Promotion Promotion { get; set; }
 
+        /// <summary>
+        /// Promotion reward type. Should be here for proper web model PromotionReward.RewardType filling
+        /// </summary>
+        public string RewardType => GetType().Name;
     }
 }

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/PromotionReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/PromotionReward.cs
@@ -4,9 +4,10 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
 {
     public abstract class PromotionReward : ValueObject
     {
-        protected PromotionReward()
+        protected PromotionReward(string rewardType)
         {
-            RewardType = Id = GetType().Name;
+            Id = GetType().Name;
+            RewardType = rewardType;
         }
 
         public string Id { get; set; }

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/ShippingRewards/ShipmentReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/ShippingRewards/ShipmentReward.cs
@@ -5,6 +5,9 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
     /// </summary>
     public class ShipmentReward : AmountBasedReward
     {
+        public ShipmentReward() : base(nameof(ShipmentReward))
+        { }
+
         public string ShippingMethod { get; set; }
         public string ShippingMethodOption { get; set; }
     }

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/SpecialOfferReward.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Rewards/SpecialOfferReward.cs
@@ -5,6 +5,7 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
     /// </summary>
     public class SpecialOfferReward : PromotionReward
     {
-      
+        public SpecialOfferReward() : base(nameof(SpecialOfferReward))
+        { }
     }
 }

--- a/tests/VirtoCommerce.MarketingModule.Test/CustomReward/NonHandledReward.cs
+++ b/tests/VirtoCommerce.MarketingModule.Test/CustomReward/NonHandledReward.cs
@@ -4,5 +4,7 @@ namespace VirtoCommerce.MarketingModule.Test.CustomReward
 {
     public class NonHandledReward : PromotionReward
     {
+        public NonHandledReward() : base(nameof(NonHandledReward))
+        { }
     }
 }


### PR DESCRIPTION
- Added PromotionReward.RewardType property with real reward object type for proper filling of webModel.PromotionReward in 'api/marketing/promotions/evaluate' API. It was filled in v2, and probably was lost during migration;