### PR TITLE
Add GetPromotionSearchCriteria to promotion policy

### DIFF
--- a/VirtoCommerce.MarketingModule.Data/Services/EvaluationPolicies/BestRewardPromotionPolicy.cs
+++ b/VirtoCommerce.MarketingModule.Data/Services/EvaluationPolicies/BestRewardPromotionPolicy.cs
@@ -31,12 +31,7 @@ namespace VirtoCommerce.MarketingModule.Data.Services
                 throw new ArgumentException($"{nameof(context)} type {context.GetType()} must be derived from PromotionEvaluationContext");
             }
 
-            var promotionSearchCriteria = new PromotionSearchCriteria
-            {
-                OnlyActive = true,
-                StoreIds = string.IsNullOrEmpty(promoContext.StoreId) ? null : new[] { promoContext.StoreId },
-                Take = int.MaxValue
-            };
+            var promotionSearchCriteria = GetPromotionSearchCriteria(promoContext);
 
             var promotions = _promotionSearchService.SearchPromotions(promotionSearchCriteria).Results;
 
@@ -134,6 +129,17 @@ namespace VirtoCommerce.MarketingModule.Data.Services
             }
 
             return retVal;
+        }
+
+        protected virtual PromotionSearchCriteria GetPromotionSearchCriteria(PromotionEvaluationContext context)
+        {
+            var searchCriteria = AbstractTypeFactory<PromotionSearchCriteria>.TryCreateInstance();
+
+            searchCriteria.OnlyActive = true;
+            searchCriteria.StoreIds = string.IsNullOrEmpty(context.StoreId) ? null : new[] { context.StoreId };
+            searchCriteria.Take = int.MaxValue;
+
+            return searchCriteria;
         }
     }
 }

--- a/VirtoCommerce.MarketingModule.Data/Services/EvaluationPolicies/CombineStackablePromotionPolicy.cs
+++ b/VirtoCommerce.MarketingModule.Data/Services/EvaluationPolicies/CombineStackablePromotionPolicy.cs
@@ -33,12 +33,7 @@ namespace VirtoCommerce.MarketingModule.Data.Services
                 throw new ArgumentException($"{nameof(context)} type {context.GetType()} must be derived from PromotionEvaluationContext");
             }
 
-            var promotionSearchCriteria = new PromotionSearchCriteria
-            {
-                OnlyActive = true,
-                StoreIds = string.IsNullOrEmpty(promoContext.StoreId) ? null : new[] { promoContext.StoreId },
-                Take = int.MaxValue
-            };
+            var promotionSearchCriteria = GetPromotionSearchCriteria(promoContext);
 
             var promotions = _promotionSearchService.SearchPromotions(promotionSearchCriteria).Results;
 
@@ -173,6 +168,17 @@ namespace VirtoCommerce.MarketingModule.Data.Services
                     }
                 }
             }
+        }
+
+        protected virtual PromotionSearchCriteria GetPromotionSearchCriteria(PromotionEvaluationContext context)
+        {
+            var searchCriteria = AbstractTypeFactory<PromotionSearchCriteria>.TryCreateInstance();
+
+            searchCriteria.OnlyActive = true;
+            searchCriteria.StoreIds = string.IsNullOrEmpty(context.StoreId) ? null : new[] { context.StoreId };
+            searchCriteria.Take = int.MaxValue;
+
+            return searchCriteria;
         }
     }
 


### PR DESCRIPTION
### Problem
When evaluate promotion we can't to filter available promotion.

### Solution
Make GetPromotionSearchCriteria method which can be overridden.

### Proposed of changes
Describe the technical details of realization provided by you.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [ ] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [ ] Check methods and variable namings - it should be self descriptive, no typos
- [ ] Check you did not introduce breaking changes in API and public models/services.
- [ ] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [ ] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [ ] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [ ] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [ ] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [ ] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
