### PR TITLE
VP-5486: Fix inactive coupon if it was added to the promotion after adding effect

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Data/Services/CouponService.cs
+++ b/src/VirtoCommerce.MarketingModule.Data/Services/CouponService.cs
@@ -99,6 +99,7 @@ namespace VirtoCommerce.MarketingModule.Data.Services
                 await repository.RemoveCouponsAsync(ids);
                 await repository.UnitOfWork.CommitAsync();
             }
+
             ClearCache();
         }
 
@@ -106,6 +107,7 @@ namespace VirtoCommerce.MarketingModule.Data.Services
         {
             CouponCacheRegion.ExpireRegion();
             PromotionSearchCacheRegion.ExpireRegion();
+
             if (promotionIds != null)
             {
                 PromotionCacheRegion.ExpirePromotions(promotionIds);

--- a/src/VirtoCommerce.MarketingModule.Data/Services/CouponService.cs
+++ b/src/VirtoCommerce.MarketingModule.Data/Services/CouponService.cs
@@ -53,6 +53,7 @@ namespace VirtoCommerce.MarketingModule.Data.Services
 
             var pkMap = new PrimaryKeyResolvingMap();
             var changedEntries = new List<GenericChangedEntry<Coupon>>();
+            
             using (var repository = _repositoryFactory())
             {
                 var existCouponEntities = await repository.GetCouponsByIdsAsync(coupons.Where(x => !x.IsTransient()).Select(x => x.Id).ToArray());
@@ -85,7 +86,7 @@ namespace VirtoCommerce.MarketingModule.Data.Services
                 await repository.UnitOfWork.CommitAsync();
                 pkMap.ResolvePrimaryKeys();
 
-                CouponCacheRegion.ExpireRegion();
+                ClearCache(coupons.Select(x => x.PromotionId).ToArray());
 
                 await _eventPublisher.Publish(new CouponChangedEvent(changedEntries));
             }
@@ -98,10 +99,18 @@ namespace VirtoCommerce.MarketingModule.Data.Services
                 await repository.RemoveCouponsAsync(ids);
                 await repository.UnitOfWork.CommitAsync();
             }
-
-            CouponCacheRegion.ExpireRegion();
+            ClearCache();
         }
 
+        private void ClearCache(string[] promotionIds = null)
+        {
+            CouponCacheRegion.ExpireRegion();
+            PromotionSearchCacheRegion.ExpireRegion();
+            if (promotionIds != null)
+            {
+                PromotionCacheRegion.ExpirePromotions(promotionIds);
+            }
+        }
         #endregion
     }
 }


### PR DESCRIPTION
### Problem
The coupon is considered inactive if it was added to the promotion after adding effect

### Solution
Clear promotion cache after any actions with coupon

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
