### PR TITLE
VP-5637: Optimize promotion blade in case of many stores

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
@@ -12,20 +12,17 @@ angular.module('virtoCommerce.marketingModule')
             blade.showPriority = data.value === 'CombineStackable';
         });
         blade.refresh = function (parentRefresh) {
-            const maxMethodsCount = 10000;
 
             var shippingMethodsPromise = !blade.shippingMethods
-                ? shippingMethods.search({ isActive: true, take: maxMethodsCount },
-                    function (data) {
-                        blade.shippingMethods = _.uniq(data.results, method => method.code);
+                ? shippingMethods.getAllRegistered(function (methods) {
+                        blade.shippingMethods = _.uniq(methods, method => method.code);
                     })
                     .$promise
                 : $q.when();
 
             var paymentMethodsPromise = !blade.paymentMethods
-                ? paymentMethods.search({ isActive: true, take: maxMethodsCount },
-                    function (data) {
-                        blade.paymentMethods = _.uniq(data.results, method => method.code);
+                ? paymentMethods.getAllRegistered(function (methods) {
+                        blade.paymentMethods = _.uniq(methods, method => method.code);
                     })
                     .$promise
                 : $q.when();

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
@@ -12,17 +12,35 @@ angular.module('virtoCommerce.marketingModule')
             blade.showPriority = data.value === 'CombineStackable';
         });
         blade.refresh = function (parentRefresh) {
-            $scope.stores = stores.query({}, function(data) {
-                _.each(data, function(store) {
-                    var storeId = store.id;
-                    shippingMethods.search({ storeId }, function (shippingMethodsData) {
-                        store.shippingMethods = _.findWhere(shippingMethodsData.results, { isActive: true }) || [];
-                    });
+            const maxMethodsCount = 10000;
 
-                    paymentMethods.search({ storeId }, function (paymentMethodsData) {
-                        store.paymentMethods = _.findWhere(paymentMethodsData.results, { isActive: true }) || [];
-                    });
-                })
+            var shippingMethodsPromise = !blade.shippingMethods
+                ? shippingMethods.search({ isActive: true, take: maxMethodsCount },
+                    function (data) {
+                        blade.shippingMethods = _.uniq(data.results, method => method.code);
+                    })
+                    .$promise
+                : $q.when();
+
+            var paymentMethodsPromise = !blade.paymentMethods
+                ? paymentMethods.search({ isActive: true, take: maxMethodsCount },
+                    function (data) {
+                        blade.paymentMethods = _.uniq(data.results, method => method.code);
+                    })
+                    .$promise
+                : $q.when();
+
+            // VP-5647: Wait for payment/shipment method loading before requesting stores and initialize dynamic tree
+            $q.all(shippingMethodsPromise, paymentMethodsPromise).then(() => initializeStores(parentRefresh));        
+        };
+
+        function initializeStores(parentRefresh) {
+            $scope.stores = stores.query({}, function (data) {
+                _.each(data, function (store) {
+                    // VP-5647: Left for backward compatibility, as virtoCommerce.dynamicExpressions.shippingMethodRewardController in Core module expects these properties to be filled in the store
+                    store.shippingMethods = blade.shippingMethods || [];
+                    store.paymentMethods = blade.paymentMethods || [];
+                });
 
                 if (blade.isNew) {
                     if (blade.isCloning) {
@@ -41,9 +59,7 @@ angular.module('virtoCommerce.marketingModule')
                     });
                 }
             });
-
-            
-        };
+        }
 
         function initializeBlade(data) {
             if (!blade.isNew) {

--- a/src/VirtoCommerce.MarketingModule.Web/module.manifest
+++ b/src/VirtoCommerce.MarketingModule.Web/module.manifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.Marketing</id>
   <version>3.10.0</version>
@@ -24,6 +24,8 @@
     <dependency id="VirtoCommerce.Core" version="3.0.0" />
     <dependency id="VirtoCommerce.Store" version="3.0.0" />
     <dependency id="VirtoCommerce.Orders" version="3.0.0" />
+    <dependency id="VirtoCommerce.Shipping" version="3.4.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.4.0" />
   </dependencies>
   <groups>
     <group>commerce</group>


### PR DESCRIPTION
Redundant requests on every store payment/shipment methods were removed.
Also there was an behavioral changes - all methods are available for rewards always (before, if stores were selected for promotion, only their payment methods were available for choosing). It seems more logical, as there is no sense in limiting available methods - there could be no store in promotion at all - so it could be applied to all stores, store could change its payment/shipping method.

It could be optimized more if could get only unique payment method codes from the server (now we are getting all methods for all stores and get unique codes from them on the client side).