### PR TITLE
VP-5647: Fill `method.id` for proper work of methods selectors UI

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
@@ -16,6 +16,10 @@ angular.module('virtoCommerce.marketingModule')
             var shippingMethodsPromise = !blade.shippingMethods
                 ? shippingMethods.getAllRegistered(function (methods) {
                         blade.shippingMethods = _.uniq(methods, method => method.code);
+                        // VP-5647: Need to fill `method.id` for proper work of methods selectors UI template from core module (e.g. expression-RewardShippingGetOfAbsShippingMethod.html)
+                        _.each(blade.shippingMethods, function (method) {
+                            method.id = method.id ? method.id : method.code;
+                        });
                     })
                     .$promise
                 : $q.when();
@@ -23,6 +27,10 @@ angular.module('virtoCommerce.marketingModule')
             var paymentMethodsPromise = !blade.paymentMethods
                 ? paymentMethods.getAllRegistered(function (methods) {
                         blade.paymentMethods = _.uniq(methods, method => method.code);
+                        // VP-5647: Need to fill `method.id` for proper work of methods selectors UI template from core module (e.g. expression-RewardShippingGetOfAbsShippingMethod.html)
+                        _.each(blade.paymentMethods, function (method) {
+                            method.id = method.id ? method.id : method.code;
+                        });
                     })
                     .$promise
                 : $q.when();


### PR DESCRIPTION
Need to fill `method.id` for proper work of methods selectors UI template from core module (e.g. [expression-RewardShippingGetOfAbsShippingMethod.html](https://github.com/VirtoCommerce/vc-module-core/blob/dev/src/VirtoCommerce.CoreModule.Web/Scripts/dynamicConditions/all-templates.html#L288))