### PR TITLE
VCST-280: right way to process multistore in promotion

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Promotion.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/Promotion.cs
@@ -13,6 +13,7 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
             IsActive = true;
         }
 
+        [Obsolete("Use StoreIds", DiagnosticId = "VC0008", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public string Store { get; set; }
 
         public IList<string> StoreIds { get; set; }

--- a/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
+++ b/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.802.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.800.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.800.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
+++ b/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
@@ -13,6 +13,5 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.802.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.800.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.800.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.MarketingModule.Data/Authorization/MarketingAuthorizationRequirement.cs
+++ b/src/VirtoCommerce.MarketingModule.Data/Authorization/MarketingAuthorizationRequirement.cs
@@ -6,7 +6,8 @@ namespace VirtoCommerce.MarketingModule.Data.Authorization
     {
         public bool CheckAllScopes { get; }
 
-        public MarketingAuthorizationRequirement(string permission) : this(permission, false)
+        public MarketingAuthorizationRequirement(string permission)
+            : this(permission, false)
         {
         }
 

--- a/src/VirtoCommerce.MarketingModule.Data/Authorization/MarketingAuthorizationRequirement.cs
+++ b/src/VirtoCommerce.MarketingModule.Data/Authorization/MarketingAuthorizationRequirement.cs
@@ -4,9 +4,16 @@ namespace VirtoCommerce.MarketingModule.Data.Authorization
 {
     public sealed class MarketingAuthorizationRequirement : PermissionAuthorizationRequirement
     {
-        public MarketingAuthorizationRequirement(string permission)
+        public bool CheckAllScopes { get; }
+
+        public MarketingAuthorizationRequirement(string permission) : this(permission, false)
+        {
+        }
+
+        public MarketingAuthorizationRequirement(string permission, bool checkAllScopes)
             : base(permission)
         {
+            CheckAllScopes = checkAllScopes;
         }
     }
 }

--- a/src/VirtoCommerce.MarketingModule.Data/Model/PromotionEntity.cs
+++ b/src/VirtoCommerce.MarketingModule.Data/Model/PromotionEntity.cs
@@ -78,7 +78,6 @@ namespace VirtoCommerce.MarketingModule.Data.Model
 
             promotion.StartDate = StartDate;
             promotion.EndDate = EndDate;
-            promotion.Store = StoreId;
             promotion.Name = Name;
             promotion.Description = Description;
             promotion.IsActive = IsActive;
@@ -93,6 +92,10 @@ namespace VirtoCommerce.MarketingModule.Data.Model
             if (Stores != null)
             {
                 promotion.StoreIds = Stores.Select(x => x.StoreId).ToList();
+
+#pragma warning disable VC0008 // Type or member is obsolete
+                promotion.Store = string.Join(", ", Stores.Select(x => x.StoreId));
+#pragma warning restore VC0008 // Type or member is obsolete
             }
             if (promotion is DynamicPromotion dynamicPromotion)
             {
@@ -124,14 +127,13 @@ namespace VirtoCommerce.MarketingModule.Data.Model
 
             StartDate = promotion.StartDate ?? DateTime.UtcNow;
             EndDate = promotion.EndDate;
-            StoreId = promotion.Store;
             Name = promotion.Name;
             Description = promotion.Description;
             IsActive = promotion.IsActive;
             EndDate = promotion.EndDate;
             Priority = promotion.Priority;
             IsExclusive = promotion.IsExclusive;
-        
+
             PerCustomerLimit = promotion.MaxPersonalUsageCount;
             TotalLimit = promotion.MaxUsageCount;
             PerCustomerLimit = promotion.MaxPersonalUsageCount;
@@ -180,6 +182,6 @@ namespace VirtoCommerce.MarketingModule.Data.Model
                 var comparer = AnonymousComparer.Create((PromotionStoreEntity entity) => entity.StoreId);
                 Stores.Patch(target.Stores, comparer, (sourceEntity, targetEntity) => targetEntity.StoreId = sourceEntity.StoreId);
             }
-        }        
+        }
     }
 }

--- a/src/VirtoCommerce.MarketingModule.Data/Repositories/MarketingDbContext.cs
+++ b/src/VirtoCommerce.MarketingModule.Data/Repositories/MarketingDbContext.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using EntityFrameworkCore.Triggers;
 using Microsoft.EntityFrameworkCore;
 using VirtoCommerce.MarketingModule.Data.Model;
 using VirtoCommerce.Platform.Data.Infrastructure;

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
@@ -41,7 +41,7 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
                 criteria.StoreIds = allowedStoreIds;
                 context.Succeed(requirement);
             }
-            if (context.Resource is DynamicPromotion promotion && (promotion.StoreIds.IsNullOrEmpty() || promotion.StoreIds.Any(x => allowedStoreIds.Contains(x))))
+            if (context.Resource is DynamicPromotion promotion && (promotion.StoreIds.IsNullOrEmpty() || promotion.StoreIds.All(x => allowedStoreIds.Contains(x))))
             {
                 context.Succeed(requirement);
             }

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
@@ -1,10 +1,13 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using VirtoCommerce.MarketingModule.Core.Model.Promotions;
 using VirtoCommerce.MarketingModule.Core.Model.Promotions.Search;
 using VirtoCommerce.MarketingModule.Core.Promotions;
+using VirtoCommerce.MarketingModule.Core.Services;
 using VirtoCommerce.MarketingModule.Data.Authorization;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
@@ -14,9 +17,13 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
 {
     public sealed class MarketingAuthorizationHandler : PermissionAuthorizationHandlerBase<MarketingAuthorizationRequirement>
     {
+        private readonly IPromotionService _promotionService;
+        private readonly ICouponService _couponService;
         private readonly MvcNewtonsoftJsonOptions _jsonOptions;
-        public MarketingAuthorizationHandler(IOptions<MvcNewtonsoftJsonOptions> jsonOptions)
+        public MarketingAuthorizationHandler(IOptions<MvcNewtonsoftJsonOptions> jsonOptions, IPromotionService promotionService, ICouponService couponService)
         {
+            _promotionService = promotionService;
+            _couponService = couponService;
             _jsonOptions = jsonOptions.Value;
         }
 
@@ -36,19 +43,50 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
 
             var storeSelectedScopes = userPermission.AssignedScopes.OfType<MarketingStoreSelectedScope>();
             var allowedStoreIds = storeSelectedScopes.Select(x => x.StoreId).Distinct().ToArray();
-            if (context.Resource is PromotionSearchCriteria criteria)
+            switch (context.Resource)
             {
-                criteria.StoreIds = allowedStoreIds;
-                context.Succeed(requirement);
-            }
-            if (context.Resource is DynamicPromotion promotion)
-            {
-                if (promotion.StoreIds.IsNullOrEmpty()
-                    || (requirement.CheckAllScopes && promotion.StoreIds.All(x => allowedStoreIds.Contains(x)))
-                    || (!requirement.CheckAllScopes && promotion.StoreIds.Any(x => allowedStoreIds.Contains(x)))
-                )
+                case PromotionSearchCriteria criteria:
+                    criteria.StoreIds = allowedStoreIds;
                     context.Succeed(requirement);
+                    break;
+                case DynamicPromotion promotion:
+                    if ((IsStoreInScope(promotion.StoreIds.ToArray(), allowedStoreIds, requirement.CheckAllScopes)))
+                    {
+                        context.Succeed(requirement);
+                    }
+                    break;
+                case IEnumerable<Coupon> coupons:
+                    if (await IsCouponsInScope(coupons, allowedStoreIds, requirement.CheckAllScopes))
+                    {
+                        context.Succeed(requirement);
+                    }
+
+                    break;
+                case string[] couponIds:
+                    {
+                        var coupons = await _couponService.GetByIdsAsync(couponIds);
+                        if (await IsCouponsInScope(coupons, allowedStoreIds, requirement.CheckAllScopes))
+                        {
+                            context.Succeed(requirement);
+                        }
+                    }
+                    break;
             }
+        }
+
+        private async Task<bool> IsCouponsInScope(IEnumerable<Coupon> coupons, string[] allowedStoreIds, bool checkAllScopes)
+        {
+            var promotionIds = coupons.Select(x => x.PromotionId).Distinct().ToArray();
+            var promotions = await _promotionService.GetPromotionsByIdsAsync(promotionIds);
+            var storesIds = promotions.SelectMany(x => x.StoreIds).ToArray();
+            return IsStoreInScope(storesIds, allowedStoreIds, checkAllScopes);
+        }
+
+        private bool IsStoreInScope(string[] currentStoreIds, string[] allowedStoreIds, bool checkAllScopes)
+        {
+            return currentStoreIds.IsNullOrEmpty()
+                   || (checkAllScopes && currentStoreIds.All(allowedStoreIds.Contains))
+                   || (!checkAllScopes && currentStoreIds.Any(allowedStoreIds.Contains));
         }
     }
 }

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
@@ -62,22 +62,24 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
                     }
 
                     break;
-                case string[] couponIds:
+                case PermissionResourceModel resource:
                     {
-                        var coupons = await _couponService.GetByIdsAsync(couponIds);
-                        if (await IsCouponsInScope(coupons, allowedStoreIds, requirement.CheckAllScopes))
+                        if (!resource.CouponIds.IsNullOrEmpty())
                         {
-                            context.Succeed(requirement);
+                            var coupons = await _couponService.GetByIdsAsync(resource.CouponIds);
+                            if (await IsCouponsInScope(coupons, allowedStoreIds, requirement.CheckAllScopes))
+                            {
+                                context.Succeed(requirement);
+                            }
                         }
-                    }
-                    break;
-                case string promotionId:
-                    {
-                        var promotions = await _promotionService.GetPromotionsByIdsAsync(new[] { promotionId });
-                        var storeIds = promotions.SelectMany(x => x.StoreIds).ToArray();
-                        if (IsStoreInScope(storeIds, allowedStoreIds, requirement.CheckAllScopes))
+                        else if (!resource.PromotionIds.IsNullOrEmpty())
                         {
-                            context.Succeed(requirement);
+                            var promotions = await _promotionService.GetPromotionsByIdsAsync(resource.PromotionIds);
+                            var storeIds = promotions.SelectMany(x => x.StoreIds).ToArray();
+                            if (IsStoreInScope(storeIds, allowedStoreIds, requirement.CheckAllScopes))
+                            {
+                                context.Succeed(requirement);
+                            }
                         }
                     }
                     break;

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
@@ -82,7 +82,7 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
             return IsStoreInScope(storesIds, allowedStoreIds, checkAllScopes);
         }
 
-        private bool IsStoreInScope(string[] currentStoreIds, string[] allowedStoreIds, bool checkAllScopes)
+        private static bool IsStoreInScope(string[] currentStoreIds, string[] allowedStoreIds, bool checkAllScopes)
         {
             return currentStoreIds.IsNullOrEmpty()
                    || (checkAllScopes && currentStoreIds.All(allowedStoreIds.Contains))

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
@@ -84,9 +84,9 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
 
         private static bool IsStoreInScope(string[] currentStoreIds, string[] allowedStoreIds, bool checkAllScopes)
         {
-            return currentStoreIds.IsNullOrEmpty()
-                   || (checkAllScopes && currentStoreIds.All(allowedStoreIds.Contains))
-                   || (!checkAllScopes && currentStoreIds.Any(allowedStoreIds.Contains));
+            return currentStoreIds.IsNullOrEmpty() || CheckAll() || CheckAny();
+            bool CheckAll() => checkAllScopes && currentStoreIds.All(allowedStoreIds.Contains);
+            bool CheckAny() => !checkAllScopes && currentStoreIds.Any(allowedStoreIds.Contains);
         }
     }
 }

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
@@ -41,9 +41,13 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
                 criteria.StoreIds = allowedStoreIds;
                 context.Succeed(requirement);
             }
-            if (context.Resource is DynamicPromotion promotion && (promotion.StoreIds.IsNullOrEmpty() || promotion.StoreIds.All(x => allowedStoreIds.Contains(x))))
+            if (context.Resource is DynamicPromotion promotion)
             {
-                context.Succeed(requirement);
+                if (promotion.StoreIds.IsNullOrEmpty()
+                    || (requirement.CheckAllScopes && promotion.StoreIds.All(x => allowedStoreIds.Contains(x)))
+                    || (!requirement.CheckAllScopes && promotion.StoreIds.Any(x => allowedStoreIds.Contains(x)))
+                )
+                    context.Succeed(requirement);
             }
         }
     }

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
@@ -71,6 +71,16 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
                         }
                     }
                     break;
+                case string promotionId:
+                    {
+                        var promotions = await _promotionService.GetPromotionsByIdsAsync(new[] { promotionId });
+                        var storeIds = promotions.SelectMany(x => x.StoreIds).ToArray();
+                        if (IsStoreInScope(storeIds, allowedStoreIds, requirement.CheckAllScopes))
+                        {
+                            context.Succeed(requirement);
+                        }
+                    }
+                    break;
             }
         }
 

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingAuthorizationHandler.cs
@@ -83,6 +83,14 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
             return await IsCouponsInScope(coupons, allowedStoreIds, checkAllScopes);
         }
 
+        private async Task<bool> IsCouponsInScope(IEnumerable<Coupon> coupons, string[] allowedStoreIds, bool checkAllScopes)
+        {
+            var promotionIds = coupons.Select(x => x.PromotionId).Distinct().ToArray();
+            var promotions = await _promotionService.GetPromotionsByIdsAsync(promotionIds);
+            var storesIds = promotions.SelectMany(x => x.StoreIds).ToArray();
+            return IsStoreInScope(storesIds, allowedStoreIds, checkAllScopes);
+        }
+
         private async Task<bool> IsPromotionsInScope(string[] promotionIds, string[] allowedStoreIds, bool checkAllScopes)
         {
             if (promotionIds.IsNullOrEmpty())
@@ -92,14 +100,6 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
             var promotions = await _promotionService.GetPromotionsByIdsAsync(promotionIds);
             var storeIds = promotions.SelectMany(x => x.StoreIds).ToArray();
             return IsStoreInScope(storeIds, allowedStoreIds, checkAllScopes);
-        }
-
-        private async Task<bool> IsCouponsInScope(IEnumerable<Coupon> coupons, string[] allowedStoreIds, bool checkAllScopes)
-        {
-            var promotionIds = coupons.Select(x => x.PromotionId).Distinct().ToArray();
-            var promotions = await _promotionService.GetPromotionsByIdsAsync(promotionIds);
-            var storesIds = promotions.SelectMany(x => x.StoreIds).ToArray();
-            return IsStoreInScope(storesIds, allowedStoreIds, checkAllScopes);
         }
 
         private static bool IsStoreInScope(string[] currentStoreIds, string[] allowedStoreIds, bool checkAllScopes)

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingStoreSelectedScope.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/MarketingStoreSelectedScope.cs
@@ -7,6 +7,6 @@ namespace VirtoCommerce.MarketingModule.Web.Authorization
     /// </summary>
     public sealed class MarketingStoreSelectedScope : PermissionScope
     {
-        public string StoreId => Scope; 
+        public string StoreId => Scope;
     }
 }

--- a/src/VirtoCommerce.MarketingModule.Web/Authorization/PermissionResourceModel.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Authorization/PermissionResourceModel.cs
@@ -1,0 +1,8 @@
+namespace VirtoCommerce.MarketingModule.Web.Authorization
+{
+    internal class PermissionResourceModel
+    {
+        public string[] CouponIds { get; set; }
+        public string[] PromotionIds { get; set; }
+    }
+}

--- a/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModuleDynamicContentController.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModuleDynamicContentController.cs
@@ -48,7 +48,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Read)]
         [HttpPost]
         [Route("contentplaces/listentries/search")]
-        public async Task<ActionResult<DynamicContentListEntrySearchResult>> DynamicContentPlaceListEntriesSearch([FromBody]coreModel.DynamicContentPlaceSearchCriteria criteria)
+        public async Task<ActionResult<DynamicContentListEntrySearchResult>> DynamicContentPlaceListEntriesSearch([FromBody] coreModel.DynamicContentPlaceSearchCriteria criteria)
         {
             var result = AbstractTypeFactory<DynamicContentListEntrySearchResult>.TryCreateInstance();
 
@@ -84,7 +84,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [HttpPost]
         [Authorize(ModuleConstants.Security.Permissions.Read)]
         [Route("contentplaces/search")]
-        public async Task<ActionResult<DynamicContentPlaceSearchResult>> DynamicContentPlacesSearch([FromBody]coreModel.DynamicContentPlaceSearchCriteria criteria)
+        public async Task<ActionResult<DynamicContentPlaceSearchResult>> DynamicContentPlacesSearch([FromBody] coreModel.DynamicContentPlaceSearchCriteria criteria)
         {
             var placesSearchResult = await _contentPlacesSearchService.SearchContentPlacesAsync(criteria);
             return Ok(placesSearchResult);
@@ -97,7 +97,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [HttpPost]
         [Authorize(ModuleConstants.Security.Permissions.Read)]
         [Route("contentitems/listentries/search")]
-        public async Task<ActionResult<DynamicContentListEntrySearchResult>> DynamicContentItemsEntriesSearch([FromBody]coreModel.DynamicContentItemSearchCriteria criteria)
+        public async Task<ActionResult<DynamicContentListEntrySearchResult>> DynamicContentItemsEntriesSearch([FromBody] coreModel.DynamicContentItemSearchCriteria criteria)
         {
             var result = AbstractTypeFactory<DynamicContentListEntrySearchResult>.TryCreateInstance();
 
@@ -124,7 +124,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [HttpPost]
         [Authorize(ModuleConstants.Security.Permissions.Read)]
         [Route("contentitems/search")]
-        public async Task<ActionResult<DynamicContentItemSearchResult>> DynamicContentItemsSearch([FromBody]coreModel.DynamicContentItemSearchCriteria criteria)
+        public async Task<ActionResult<DynamicContentItemSearchResult>> DynamicContentItemsSearch([FromBody] coreModel.DynamicContentItemSearchCriteria criteria)
         {
             var itemsSearchResult = await _contentItemsSearchService.SearchContentItemsAsync(criteria);
             return Ok(itemsSearchResult);
@@ -137,7 +137,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [HttpPost]
         [Authorize(ModuleConstants.Security.Permissions.Read)]
         [Route("contentpublications/search")]
-        public async Task<ActionResult<DynamicContentPublicationSearchResult>> DynamicContentPublicationsSearch([FromBody]coreModel.DynamicContentPublicationSearchCriteria criteria)
+        public async Task<ActionResult<DynamicContentPublicationSearchResult>> DynamicContentPublicationsSearch([FromBody] coreModel.DynamicContentPublicationSearchCriteria criteria)
         {
             var publicationSearchResult = await _contentPublicationsSearchService.SearchContentPublicationsAsync(criteria);
             return Ok(publicationSearchResult);
@@ -149,7 +149,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [HttpPost]
         [Authorize(ModuleConstants.Security.Permissions.Read)]
         [Route("contentitems/evaluate")]
-        public async Task<ActionResult<coreModel.DynamicContentItem[]>> EvaluateDynamicContent([FromBody]coreModel.DynamicContentEvaluationContext evalContext)
+        public async Task<ActionResult<coreModel.DynamicContentItem[]>> EvaluateDynamicContent([FromBody] coreModel.DynamicContentEvaluationContext evalContext)
         {
             var items = await _dynamicContentEvaluator.EvaluateItemsAsync(evalContext);
             return Ok(items);
@@ -181,7 +181,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [HttpPost]
         [Route("contentitems")]
         [Authorize(ModuleConstants.Security.Permissions.Create)]
-        public async Task<ActionResult<coreModel.DynamicContentItem>> CreateDynamicContent([FromBody]coreModel.DynamicContentItem contentItem)
+        public async Task<ActionResult<coreModel.DynamicContentItem>> CreateDynamicContent([FromBody] coreModel.DynamicContentItem contentItem)
         {
             await _dynamicContentService.SaveContentItemsAsync(new[] { contentItem });
             return await GetDynamicContentById(contentItem.Id);
@@ -195,7 +195,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Route("contentitems")]
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
-        public ActionResult UpdateDynamicContent([FromBody]coreModel.DynamicContentItem contentItem)
+        public ActionResult UpdateDynamicContent([FromBody] coreModel.DynamicContentItem contentItem)
         {
             _dynamicContentService.SaveContentItemsAsync(new[] { contentItem });
             return NoContent();
@@ -241,7 +241,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [HttpPost]
         [Route("contentplaces")]
         [Authorize(ModuleConstants.Security.Permissions.Create)]
-        public async Task<ActionResult<coreModel.DynamicContentPlace>> CreateDynamicContentPlace([FromBody]coreModel.DynamicContentPlace contentPlace)
+        public async Task<ActionResult<coreModel.DynamicContentPlace>> CreateDynamicContentPlace([FromBody] coreModel.DynamicContentPlace contentPlace)
         {
             await _dynamicContentService.SavePlacesAsync(new[] { contentPlace });
             return await GetDynamicContentPlaceById(contentPlace.Id);
@@ -255,7 +255,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Route("contentplaces")]
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
-        public async Task<ActionResult> UpdateDynamicContentPlace([FromBody]coreModel.DynamicContentPlace contentPlace)
+        public async Task<ActionResult> UpdateDynamicContentPlace([FromBody] coreModel.DynamicContentPlace contentPlace)
         {
             await _dynamicContentService.SavePlacesAsync(new[] { contentPlace });
             return NoContent();
@@ -319,7 +319,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [HttpPost]
         [Route("contentpublications")]
         [Authorize(ModuleConstants.Security.Permissions.Create)]
-        public async Task<ActionResult<coreModel.DynamicContentPublication>> CreateDynamicContentPublication([FromBody]coreModel.DynamicContentPublication publication)
+        public async Task<ActionResult<coreModel.DynamicContentPublication>> CreateDynamicContentPublication([FromBody] coreModel.DynamicContentPublication publication)
         {
             await _dynamicContentService.SavePublicationsAsync(new[] { publication });
             return await GetDynamicContentPublicationById(publication.Id);
@@ -333,7 +333,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Route("contentpublications")]
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
-        public async Task<ActionResult> UpdateDynamicContentPublication([FromBody]coreModel.DynamicContentPublication publication)
+        public async Task<ActionResult> UpdateDynamicContentPublication([FromBody] coreModel.DynamicContentPublication publication)
         {
             await _dynamicContentService.SavePublicationsAsync(new[] { publication });
             return NoContent();
@@ -378,7 +378,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [HttpPost]
         [Route("contentfolders")]
         [Authorize(ModuleConstants.Security.Permissions.Create)]
-        public async Task<ActionResult<coreModel.DynamicContentFolder>> CreateDynamicContentFolder([FromBody]coreModel.DynamicContentFolder folder)
+        public async Task<ActionResult<coreModel.DynamicContentFolder>> CreateDynamicContentFolder([FromBody] coreModel.DynamicContentFolder folder)
         {
             await _dynamicContentService.SaveFoldersAsync(new[] { folder });
             return await GetDynamicContentFolderById(folder.Id);
@@ -392,7 +392,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Route("contentfolders")]
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
-        public async Task<ActionResult> UpdateDynamicContentFolder([FromBody]coreModel.DynamicContentFolder folder)
+        public async Task<ActionResult> UpdateDynamicContentFolder([FromBody] coreModel.DynamicContentFolder folder)
         {
             await _dynamicContentService.SaveFoldersAsync(new[] { folder });
             return NoContent();

--- a/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
@@ -21,7 +21,6 @@ using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.ExportImport;
 using VirtoCommerce.Platform.Core.PushNotifications;
 using VirtoCommerce.Platform.Core.Security;
-using StorePermissions = VirtoCommerce.StoreModule.Core.ModuleConstants.Security.Permissions;
 using webModel = VirtoCommerce.MarketingModule.Web.Model;
 
 namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
@@ -169,7 +168,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult> UpdatePromotions([FromBody] Promotion promotion)
         {
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(StorePermissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -188,7 +187,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         public async Task<ActionResult> DeletePromotions([FromQuery] string[] ids)
         {
             var permissionResource = new PermissionResourceModel { PromotionIds = ids };
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(StorePermissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -247,7 +246,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         public async Task<ActionResult> DeleteCoupons([FromQuery] string[] ids)
         {
             var permissionResource = new PermissionResourceModel { CouponIds = ids };
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(StorePermissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -264,7 +263,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         public async Task<ActionResult<ImportNotification>> ImportCouponsAsync([FromBody] ImportRequest request)
         {
             var permissionResource = new PermissionResourceModel { PromotionIds = new[] { request.PromotionId } };
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(StorePermissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();

--- a/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
@@ -74,7 +74,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         public async Task<ActionResult<PromotionSearchResult>> PromotionsSearch([FromBody] PromotionSearchCriteria criteria)
         {
             //Scope bound ACL filtration
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, criteria, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, criteria, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -112,7 +112,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
             var result = promotions.FirstOrDefault();
             if (result != null)
             {
-                var authorizationResult = await _authorizationService.AuthorizeAsync(User, result, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read));
+                var authorizationResult = await _authorizationService.AuthorizeAsync(User, result, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, false));
                 if (!authorizationResult.Succeeded)
                 {
                     return Forbid();
@@ -167,7 +167,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult> UpdatePromotions([FromBody] Promotion promotion)
         {
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();

--- a/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
@@ -76,7 +76,8 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         public async Task<ActionResult<PromotionSearchResult>> PromotionsSearch([FromBody] PromotionSearchCriteria criteria)
         {
             //Scope bound ACL filtration
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, criteria, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(
+                User, criteria, new MarketingAuthorizationRequirement(Permissions.Read, checkAllScopes: true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -114,7 +115,8 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
             var result = promotions.FirstOrDefault();
             if (result != null)
             {
-                var authorizationResult = await _authorizationService.AuthorizeAsync(User, result, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, false));
+                var authorizationResult = await _authorizationService.AuthorizeAsync(
+                    User, result, new MarketingAuthorizationRequirement(Permissions.Read, checkAllScopes: false));
                 if (!authorizationResult.Succeeded)
                 {
                     return Forbid();
@@ -169,7 +171,8 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult> UpdatePromotions([FromBody] Promotion promotion)
         {
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(Permissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(
+                User, promotion, new MarketingAuthorizationRequirement(Permissions.Read, checkAllScopes: true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();

--- a/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
@@ -167,6 +167,11 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult> UpdatePromotions([FromBody] Promotion promotion)
         {
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read));
+            if (!authorizationResult.Succeeded)
+            {
+                return Forbid();
+            }
             await _promotionService.SavePromotionsAsync(new[] { promotion });
             return NoContent();
         }

--- a/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
@@ -254,6 +254,12 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult<ImportNotification>> ImportCouponsAsync([FromBody] ImportRequest request)
         {
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, request.PromotionId, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            if (!authorizationResult.Succeeded)
+            {
+                return Forbid();
+            }
+
             var notification = new ImportNotification(_userNameResolver.GetCurrentUserName())
             {
                 Title = "Import coupons from CSV",

--- a/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
@@ -15,11 +15,13 @@ using VirtoCommerce.MarketingModule.Core.Search;
 using VirtoCommerce.MarketingModule.Core.Services;
 using VirtoCommerce.MarketingModule.Data.Authorization;
 using VirtoCommerce.MarketingModule.Data.Repositories;
+using VirtoCommerce.MarketingModule.Web.Authorization;
 using VirtoCommerce.MarketingModule.Web.ExportImport;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.ExportImport;
 using VirtoCommerce.Platform.Core.PushNotifications;
 using VirtoCommerce.Platform.Core.Security;
+using StorePermissions = VirtoCommerce.StoreModule.Core.ModuleConstants.Security.Permissions;
 using webModel = VirtoCommerce.MarketingModule.Web.Model;
 
 namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
@@ -167,7 +169,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult> UpdatePromotions([FromBody] Promotion promotion)
         {
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(StorePermissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -185,6 +187,12 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Delete)]
         public async Task<ActionResult> DeletePromotions([FromQuery] string[] ids)
         {
+            var permissionResource = new PermissionResourceModel { PromotionIds = ids };
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(StorePermissions.Read, true));
+            if (!authorizationResult.Succeeded)
+            {
+                return Forbid();
+            }
             await _promotionService.DeletePromotionsAsync(ids);
             return NoContent();
         }
@@ -238,7 +246,8 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Delete)]
         public async Task<ActionResult> DeleteCoupons([FromQuery] string[] ids)
         {
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, ids, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            var permissionResource = new PermissionResourceModel { CouponIds = ids };
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(StorePermissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -254,7 +263,8 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult<ImportNotification>> ImportCouponsAsync([FromBody] ImportRequest request)
         {
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, request.PromotionId, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            var permissionResource = new PermissionResourceModel { PromotionIds = new[] { request.PromotionId } };
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(StorePermissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();

--- a/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
@@ -222,6 +222,12 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult> AddCoupons([FromBody] Coupon[] coupons)
         {
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, coupons, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            if (!authorizationResult.Succeeded)
+            {
+                return Forbid();
+            }
+
             await _couponService.SaveCouponsAsync(coupons);
 
             return NoContent();
@@ -232,6 +238,12 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Delete)]
         public async Task<ActionResult> DeleteCoupons([FromQuery] string[] ids)
         {
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, ids, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            if (!authorizationResult.Succeeded)
+            {
+                return Forbid();
+            }
+
             await _couponService.DeleteCouponsAsync(ids);
 
             return NoContent();

--- a/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Controllers/Api/MarketingModulePromotionController.cs
@@ -21,6 +21,7 @@ using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.ExportImport;
 using VirtoCommerce.Platform.Core.PushNotifications;
 using VirtoCommerce.Platform.Core.Security;
+using Permissions = VirtoCommerce.MarketingModule.Core.ModuleConstants.Security.Permissions;
 using webModel = VirtoCommerce.MarketingModule.Web.Model;
 
 namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
@@ -168,7 +169,7 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult> UpdatePromotions([FromBody] Promotion promotion)
         {
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(User, promotion, new MarketingAuthorizationRequirement(Permissions.Read, true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -187,7 +188,8 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         public async Task<ActionResult> DeletePromotions([FromQuery] string[] ids)
         {
             var permissionResource = new PermissionResourceModel { PromotionIds = ids };
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(
+                User, permissionResource, new MarketingAuthorizationRequirement(Permissions.Read, checkAllScopes: true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -229,7 +231,8 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         [Authorize(ModuleConstants.Security.Permissions.Update)]
         public async Task<ActionResult> AddCoupons([FromBody] Coupon[] coupons)
         {
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, coupons, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(
+                User, coupons, new MarketingAuthorizationRequirement(Permissions.Read, checkAllScopes: true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -246,7 +249,8 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         public async Task<ActionResult> DeleteCoupons([FromQuery] string[] ids)
         {
             var permissionResource = new PermissionResourceModel { CouponIds = ids };
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(
+                User, permissionResource, new MarketingAuthorizationRequirement(Permissions.Read, checkAllScopes: true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();
@@ -263,7 +267,8 @@ namespace VirtoCommerce.MarketingModule.Web.Controllers.Api
         public async Task<ActionResult<ImportNotification>> ImportCouponsAsync([FromBody] ImportRequest request)
         {
             var permissionResource = new PermissionResourceModel { PromotionIds = new[] { request.PromotionId } };
-            var authorizationResult = await _authorizationService.AuthorizeAsync(User, permissionResource, new MarketingAuthorizationRequirement(ModuleConstants.Security.Permissions.Read, true));
+            var authorizationResult = await _authorizationService.AuthorizeAsync(
+                User, permissionResource, new MarketingAuthorizationRequirement(Permissions.Read, checkAllScopes: true));
             if (!authorizationResult.Succeeded)
             {
                 return Forbid();

--- a/src/VirtoCommerce.MarketingModule.Web/Localizations/en.VirtoCommerce.Marketing.json
+++ b/src/VirtoCommerce.MarketingModule.Web/Localizations/en.VirtoCommerce.Marketing.json
@@ -50,7 +50,8 @@
         },
         "toolbar": {
           "coupons": "Coupons"
-        }
+        },
+        "cant-be-saved": "You are currently limited to the scope of the stores and the selected promotion is assigned to multiple stores. Editing this promotion is not allowed."
       },
       "coupon-detail": {
         "new-title": "New coupon",

--- a/src/VirtoCommerce.MarketingModule.Web/Localizations/en.VirtoCommerce.Marketing.json
+++ b/src/VirtoCommerce.MarketingModule.Web/Localizations/en.VirtoCommerce.Marketing.json
@@ -51,7 +51,7 @@
         "toolbar": {
           "coupons": "Coupons"
         },
-        "cant-be-saved": "You are currently limited to the scope of the stores and the selected promotion is assigned to multiple stores. Editing this promotion is not allowed."
+        "cannot-be-saved": "You are currently limited to the scope of the stores and the selected promotion is assigned to multiple stores. Editing this promotion is not allowed."
       },
       "coupon-detail": {
         "new-title": "New coupon",

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-detail.js
@@ -48,7 +48,7 @@ angular.module('virtoCommerce.marketingModule')
                     return isDirty()
                         && $scope.formCoupon
                         && $scope.formCoupon.$valid
-                        && blade.showErrorStoreStateMessage;
+                        && blade.showErrorStoreStateMessage !== true;
                 };
 
                 $scope.saveChanges = function () {

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-detail.js
@@ -47,7 +47,8 @@ angular.module('virtoCommerce.marketingModule')
                 $scope.isValid = function () {
                     return isDirty()
                         && $scope.formCoupon
-                        && $scope.formCoupon.$valid;
+                        && $scope.formCoupon.$valid
+                        && blade.showErrorStoreStateMessage;
                 };
 
                 $scope.saveChanges = function () {

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-detail.tpl.html
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-detail.tpl.html
@@ -11,7 +11,7 @@
                             <svg class="vc-alert__icon">
                                 <use href="/images/error.svg#icon"></use>
                             </svg>
-                            <div class="vc-alert__text">{{ 'marketing.blades.promotion-detail.cant-be-saved' | translate }}</div>
+                            <div class="vc-alert__text">{{ 'marketing.blades.promotion-detail.cannot-be-saved' | translate }}</div>
                         </div>
                     </div>
                 </div>

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-detail.tpl.html
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-detail.tpl.html
@@ -5,7 +5,16 @@
     <div class="blade-inner">
         <div class="inner-block">
             <form class="form" method="post" name="formCoupon" novalidate="novalidate">
-
+                <div class="form-group clearfix" ng-if="blade.showErrorStoreStateMessage">
+                    <div class="form-error">
+                        <div class="vc-alert vc-alert--warning">
+                            <svg class="vc-alert__icon">
+                                <use href="/images/error.svg#icon"></use>
+                            </svg>
+                            <div class="vc-alert__text">{{ 'marketing.blades.promotion-detail.cant-be-saved' | translate }}</div>
+                        </div>
+                    </div>
+                </div>
                 <div class="form-group clearfix" ng-init="setForm(formCoupon)">
                     <div class="column">
                         <div class="form-group __info list">

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-list.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-list.js
@@ -32,7 +32,7 @@ function ($scope, $localStorage, dialogService, bladeUtils, uiGridHelper, promot
         blade.refresh();
     });
 
-    var hasPlarformAssetsPermission = bladeNavigationService.checkPermission('platform:asset:read');
+    var hasPlarformAssetsPermission = bladeNavigationService.checkPermission('platform:asset:create');
 
     blade.toolbarCommands = [{
         name: 'marketing.blades.coupons.toolbar.add',

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-list.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-list.js
@@ -32,7 +32,7 @@ function ($scope, $localStorage, dialogService, bladeUtils, uiGridHelper, promot
         blade.refresh();
     });
 
-    var hasPlarformAssetsPermission = bladeNavigationService.checkPermission('platform:assets:read');
+    var hasPlarformAssetsPermission = bladeNavigationService.checkPermission('platform:asset:read');
 
     blade.toolbarCommands = [{
         name: 'marketing.blades.coupons.toolbar.add',

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-list.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-list.js
@@ -32,18 +32,20 @@ function ($scope, $localStorage, dialogService, bladeUtils, uiGridHelper, promot
         blade.refresh();
     });
 
+    var hasPlarformAssetsPermission = bladeNavigationService.checkPermission('platform:assets:read');
+
     blade.toolbarCommands = [{
         name: 'marketing.blades.coupons.toolbar.add',
         icon: 'fas fa-plus',
         canExecuteMethod: function () {
-            return true;
+            return blade.parentBlade.showErrorStoreStateMessage !== true;
         },
         executeMethod: showAddCouponBlade
     }, {
         name: 'marketing.blades.coupons.toolbar.import',
         icon: 'fa fa-download',
         canExecuteMethod: function () {
-            return true;
+            return hasPlarformAssetsPermission && blade.parentBlade.showErrorStoreStateMessage !== true;
         },
         executeMethod: showCouponImportBlade
     }, {

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-list.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/coupon-list.js
@@ -100,6 +100,7 @@ function ($scope, $localStorage, dialogService, bladeUtils, uiGridHelper, promot
             id: 'couponDetail',
             originalEntity: angular.copy(node),
             currentEntity: angular.copy(node),
+            showErrorStoreStateMessage: blade.parentBlade.showErrorStoreStateMessage,
             title: 'Coupon "' + node.code + '"',
             controller: 'virtoCommerce.marketingModule.couponDetailController',
             template: 'Modules/$(VirtoCommerce.Marketing)/Scripts/promotion/blades/coupon-detail.tpl.html'

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
@@ -8,7 +8,7 @@ angular.module('virtoCommerce.marketingModule')
         blade.expressionTreeTemplateUrl = dynamicExpressionService.expressionTreeTemplateUrl;
 
         blade.showPriority = false;
-        $scope.showErrorStoreStateMessage = null;
+        blade.showErrorStoreStateMessage = null;
 
         settings.get({ id: 'Marketing.Promotion.CombinePolicy' }, function (data) {
             blade.showPriority = data.value === 'CombineStackable';
@@ -322,13 +322,13 @@ angular.module('virtoCommerce.marketingModule')
             const unknownStores = _.difference(blade.currentEntity.storeIds, _.pluck($scope.stores, 'id'));
             if (unknownStores.length) {
                 $("#storesContainer .ui-select-container").addClass("ng-invalid");
-                if ($scope.showErrorStoreStateMessage === null) {
-                    $scope.showErrorStoreStateMessage = true;
+                if (blade.showErrorStoreStateMessage === null) {
+                    blade.showErrorStoreStateMessage = true;
                 }
             } else {
                 $("#storesContainer .ui-select-container").removeClass("ng-invalid");
             }
-            return !unknownStores.length && !$scope.showErrorStoreStateMessage;
+            return !unknownStores.length && !blade.showErrorStoreStateMessage;
         };
 
         function joinStores(newItems) {
@@ -346,7 +346,7 @@ angular.module('virtoCommerce.marketingModule')
         }
 
         function initStoreStateErrorMessage() {
-            $scope.showErrorStoreStateMessage = bladeNavigationService.checkPermission() // isAdmin
+            blade.showErrorStoreStateMessage = bladeNavigationService.checkPermission() // isAdmin
                 ? false
                 : null;
         }

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
@@ -8,6 +8,10 @@ angular.module('virtoCommerce.marketingModule')
         blade.expressionTreeTemplateUrl = dynamicExpressionService.expressionTreeTemplateUrl;
 
         blade.showPriority = false;
+        $scope.showErrorStoreStateMessage = bladeNavigationService.checkPermission() // isAdmin
+            ? false
+            : null;
+
         settings.get({ id: 'Marketing.Promotion.CombinePolicy' }, function (data) {
             blade.showPriority = data.value === 'CombineStackable';
         });
@@ -119,7 +123,8 @@ angular.module('virtoCommerce.marketingModule')
         $scope.isValid = function () {
             return isDirty()
                 && $scope.formScope
-                && $scope.formScope.$valid;
+                && $scope.formScope.$valid
+                && $scope.validateStores();
             //&& (!blade.currentEntity.dynamicExpression;
             //    || (blade.currentEntity.dynamicExpression.children[0].children.length > 0
             //        && blade.currentEntity.dynamicExpression.children[3].children.length > 0));
@@ -283,7 +288,7 @@ angular.module('virtoCommerce.marketingModule')
 
             return $q.resolve();
         }
-
+        
         $scope.fetchNextStores = ($select) => {
             $select.page = $select.page || 0;
 
@@ -312,6 +317,19 @@ angular.module('virtoCommerce.marketingModule')
             }
 
             return $q.resolve();
+        };
+
+        $scope.validateStores = function () {
+            const unknownStores = _.difference(blade.currentEntity.storeIds, _.pluck($scope.stores, 'id'));
+            if (unknownStores.length) {
+                $("#storesContainer .ui-select-container").addClass("ng-invalid");
+                if ($scope.showErrorStoreStateMessage === null) {
+                    $scope.showErrorStoreStateMessage = true;
+                }
+            } else {
+                $("#storesContainer .ui-select-container").removeClass("ng-invalid");
+            }
+            return !unknownStores.length && !$scope.showErrorStoreStateMessage;
         };
 
         function joinStores(newItems) {

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
@@ -8,9 +8,7 @@ angular.module('virtoCommerce.marketingModule')
         blade.expressionTreeTemplateUrl = dynamicExpressionService.expressionTreeTemplateUrl;
 
         blade.showPriority = false;
-        $scope.showErrorStoreStateMessage = bladeNavigationService.checkPermission() // isAdmin
-            ? false
-            : null;
+        $scope.showErrorStoreStateMessage = null;
 
         settings.get({ id: 'Marketing.Promotion.CombinePolicy' }, function (data) {
             blade.showPriority = data.value === 'CombineStackable';
@@ -320,6 +318,7 @@ angular.module('virtoCommerce.marketingModule')
         };
 
         $scope.validateStores = function () {
+            if (!$scope.stores.length) { return true; }
             const unknownStores = _.difference(blade.currentEntity.storeIds, _.pluck($scope.stores, 'id'));
             if (unknownStores.length) {
                 $("#storesContainer .ui-select-container").addClass("ng-invalid");
@@ -342,6 +341,14 @@ angular.module('virtoCommerce.marketingModule')
             });
 
             $scope.stores = $scope.stores.concat(newItems);
+            initStoreStateErrorMessage();
+            $scope.validateStores();
+        }
+
+        function initStoreStateErrorMessage() {
+            $scope.showErrorStoreStateMessage = bladeNavigationService.checkPermission() // isAdmin
+                ? false
+                : null;
         }
 
         blade.refresh(false);

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
@@ -286,7 +286,7 @@ angular.module('virtoCommerce.marketingModule')
 
             return $q.resolve();
         }
-        
+
         $scope.fetchNextStores = ($select) => {
             $select.page = $select.page || 0;
 
@@ -318,7 +318,9 @@ angular.module('virtoCommerce.marketingModule')
         };
 
         $scope.validateStores = function () {
-            if (!$scope.stores.length) { return true; }
+            if (!$scope.stores.length) {
+                return true;
+            }
             const unknownStores = _.difference(blade.currentEntity.storeIds, _.pluck($scope.stores, 'id'));
             if (unknownStores.length) {
                 $("#storesContainer .ui-select-container").addClass("ng-invalid");

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.tpl.html
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.tpl.html
@@ -6,6 +6,16 @@
         <div class="inner-block">
           <form class="form" name="formScope">
             <fieldset ng-init="setForm(formScope)">
+              <div class="form-group clearfix" ng-if="showErrorStoreStateMessage">
+                <div class="form-error">
+                  <div class="vc-alert vc-alert--warning">
+                    <svg class="vc-alert__icon">
+                      <use href="/images/error.svg#icon"></use>
+                    </svg>
+                    <div class="vc-alert__text">{{ 'marketing.blades.promotion-detail.cant-be-saved' | translate }}</div>
+                  </div>
+                </div>
+              </div>
               <div class="form-group clearfix">
                 <div class="column">
                   <div class="form-group __info list">
@@ -68,9 +78,9 @@
                 <div class="column">
                   <div class="form-group __info list">
                     <label class="form-label">{{ 'marketing.blades.promotion-detail.labels.store' | translate }}</label>
-                    <div class="form-input">
-                      <ui-select multiple ng-model="blade.currentEntity.storeIds" ng-class="{disabled: stores.length === 0}">
-                        <ui-select-match placeholder="{{'marketing.blades.promotion-detail.placeholders.store' | translate}}">{{stores.length > 0 ? $item.name : 'Loading...'}}</ui-select-match>
+                    <div class="form-input" id="storesContainer">
+                      <ui-select on-select="validateStores()" on-remove="validateStores()" multiple ng-model="blade.currentEntity.storeIds" ng-class="{disabled: stores.length === 0}">
+                        <ui-select-match placeholder="{{'marketing.blades.promotion-detail.placeholders.store' | translate}}">{{stores.length > 0 ? ($item.name || 'UNKNOWN') : 'Loading...'}}</ui-select-match>
                         <ui-select-choices repeat="x.id as x in stores | filter: { name: $select.search }" refresh="fetchStores($select)" refresh-delay="300" when-scrolled="fetchNextStores($select)">
                           <span ng-bind-html="x.name | highlight: $select.search" ng-show='stores.length > 0'></span>
                         </ui-select-choices>
@@ -86,7 +96,6 @@
 
 
             <va-widget-container group="promotionDetail" blade="blade" data="blade.currentEntity" gridster-opts="{width: 526}"></va-widget-container>
-            <!--ui-validate=" 'promotionExpressionValidator(blade.isExpresionValid)' " ng-model="blade.isExpresionValid"-->
             <fieldset ng-if="blade.currentEntity.dynamicExpression && blade.currentEntity.type==='DynamicPromotion'">
               <legend>{{ 'marketing.blades.promotion-detail.labels.promotion-conditions' | translate }}</legend>
               <div class="dynamic-expression">

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.tpl.html
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.tpl.html
@@ -80,7 +80,11 @@
                     <label class="form-label">{{ 'marketing.blades.promotion-detail.labels.store' | translate }}</label>
                     <div class="form-input" id="storesContainer">
                       <ui-select on-select="validateStores()" on-remove="validateStores()" multiple ng-model="blade.currentEntity.storeIds" ng-class="{disabled: stores.length === 0}">
-                        <ui-select-match placeholder="{{'marketing.blades.promotion-detail.placeholders.store' | translate}}">{{stores.length > 0 ? ($item.name || 'UNKNOWN') : 'Loading...'}}</ui-select-match>
+                        <ui-select-match placeholder="{{'marketing.blades.promotion-detail.placeholders.store' | translate}}">
+                          <span ng-if="stores.length && $item.name">{{$item.name}}</span>
+                          <span style="color: #f50000;font-weight: bold;" ng-if="stores.length && !$item.name">UNKNOWN</span>
+                          <span ng-if="!stores.length">Loading...</span>
+                        </ui-select-match>
                         <ui-select-choices repeat="x.id as x in stores | filter: { name: $select.search }" refresh="fetchStores($select)" refresh-delay="300" when-scrolled="fetchNextStores($select)">
                           <span ng-bind-html="x.name | highlight: $select.search" ng-show='stores.length > 0'></span>
                         </ui-select-choices>

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.tpl.html
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.tpl.html
@@ -12,7 +12,7 @@
                     <svg class="vc-alert__icon">
                       <use href="/images/error.svg#icon"></use>
                     </svg>
-                    <div class="vc-alert__text">{{ 'marketing.blades.promotion-detail.cant-be-saved' | translate }}</div>
+                    <div class="vc-alert__text">{{ 'marketing.blades.promotion-detail.cannot-be-saved' | translate }}</div>
                   </div>
                 </div>
               </div>

--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.tpl.html
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.tpl.html
@@ -6,7 +6,7 @@
         <div class="inner-block">
           <form class="form" name="formScope">
             <fieldset ng-init="setForm(formScope)">
-              <div class="form-group clearfix" ng-if="showErrorStoreStateMessage">
+              <div class="form-group clearfix" ng-if="blade.showErrorStoreStateMessage">
                 <div class="form-error">
                   <div class="vc-alert vc-alert--warning">
                     <svg class="vc-alert__icon">


### PR DESCRIPTION
## Description

* display **UNKNOWN** word instead of empty box for store labels
* Forbid to save promotions with unknown stores for managers
* Check scopes when promotion is under updating

## References
### QA-test:
### Jira-link:















https://virtocommerce.atlassian.net/browse/VCST-280
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Marketing_3.804.0-pr-224-71d3.zip
