### PR TITLE
Added extensibility point to prepare data for changed promotion

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
+++ b/src/VirtoCommerce.MarketingModule.Web/Scripts/promotion/blades/promotion-detail.js
@@ -67,20 +67,25 @@ angular.module('virtoCommerce.marketingModule')
                 blade.title = data.name;
             }
 
-            // transform simple string to complex object. Simple string isn't editable.
-            data.coupons = _.map(data.coupons, function (x) { return { text: x }; });
-
             blade.expressionPromises = [];
-            if (data.dynamicExpression) {
-                _.each(data.dynamicExpression.children, extendElementBlock);
-            }
 
-            $q.all(blade.expressionPromises).then(function (allData) {
+            blade.prepareData(data).then(function () {
                 blade.currentEntity = angular.copy(data);
                 blade.origEntity = data;
             }).finally(function () {
                 blade.isLoading = false;
             });
+        }
+
+        blade.prepareData = function (data) {
+            // transform simple string to complex object. Simple string isn't editable.
+            data.coupons = _.map(data.coupons, function (x) { return { text: x }; });
+
+            if (data.dynamicExpression) {
+                _.each(data.dynamicExpression.children, extendElementBlock);
+            }
+
+            return $q.all(blade.expressionPromises);
         }
 
         function isDirty() {


### PR DESCRIPTION
## Description
Marketing module scripts do some additional work after loading promotion, such as transforming coupons or preparing dynamic expression blocks, including loading additional data for categories and products. This change moves this code into additional function which can be called if promotion was created or changed outside of the blade and then passed to it.

In module:
```js
initialzieBladeData(data)

...

function initializeBladeData(data)
{
  ...
  blade.prepareData(data)
  ...
}
```

From outside:
```js
api.update(options, function (data) // created or updated promotion
{
  blade.parentBlade.prepareData(data).then(function () {
    blade.parentBlade.currentEntity = data;
  });
});
```

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Marketing_3.807.0-pr-227-be37.zip