### PR TITLE
VCST-3663: Fix spelling of OrganizationId

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/DynamicPromotion.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/DynamicPromotion.cs
@@ -168,7 +168,7 @@ namespace VirtoCommerce.MarketingModule.Core.Promotions
 
                         if (couponIsValid && !string.IsNullOrWhiteSpace(coupon.MemberId))
                         {
-                            couponIsValid = coupon.MemberId == promoContext.ContactId || coupon.MemberId == promoContext.OrganizaitonId;
+                            couponIsValid = coupon.MemberId == promoContext.ContactId || coupon.MemberId == promoContext.OrganizationId;
                         }
 
                         if (couponIsValid)

--- a/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/PromotionEvaluationContext.cs
+++ b/src/VirtoCommerce.MarketingModule.Core/Model/Promotions/PromotionEvaluationContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using VirtoCommerce.CoreModule.Core.Common;
@@ -41,7 +42,15 @@ namespace VirtoCommerce.MarketingModule.Core.Model.Promotions
         }
 
         public string ContactId { get; set; }
-        public string OrganizaitonId { get; set; }
+
+        [Obsolete("Use OrganizationId instead.", DiagnosticId = "VC0011", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
+        public string OrganizaitonId
+        {
+            get => OrganizationId;
+            set => OrganizationId = value;
+        }
+
+        public string OrganizationId { get; set; }
 
         public bool IsRegisteredUser { get; set; }
 


### PR DESCRIPTION
## Description
fix: Fix spelling of OrganizationId. Introduced a new property OrganizationId and marked the existing OrganizaitonId as obsolete.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-3663
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Marketing_3.820.0-pr-248-ed89.zip