### PR TITLE
VCST-4902: Case Insensitive Search for PostgreSQL

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
+++ b/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
@@ -12,6 +12,6 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
+++ b/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
@@ -12,6 +12,6 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.MarketingModule.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.MarketingModule.Data.MySql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.5
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.5
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.MarketingModule.Data.MySql/VirtoCommerce.MarketingModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.MarketingModule.Data.MySql/VirtoCommerce.MarketingModule.Data.MySql.csproj
@@ -3,15 +3,14 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Data\VirtoCommerce.MarketingModule.Data.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/CouponEntityConfiguration.cs
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/CouponEntityConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.MarketingModule.Data.Model;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+namespace VirtoCommerce.MarketingModule.Data.PostgreSql;
+
+public class CouponEntityConfiguration : IEntityTypeConfiguration<CouponEntity>
+{
+    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<CouponEntity> builder)
+    {
+        // Configure the entity here
+        builder.Property(x => x.Code).UseCaseInsensitiveCollation();
+    }
+}

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/DynamicContentFolderEntityConfiguration.cs
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/DynamicContentFolderEntityConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.MarketingModule.Data.Model;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+namespace VirtoCommerce.MarketingModule.Data.PostgreSql;
+
+public class DynamicContentFolderEntityConfiguration : IEntityTypeConfiguration<DynamicContentFolderEntity>
+{
+    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<DynamicContentFolderEntity> builder)
+    {
+        // Configure the entity here
+        builder.Property(x => x.Name).UseCaseInsensitiveCollation();
+    }
+}

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/DynamicContentItemEntityConfiguration.cs
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/DynamicContentItemEntityConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.MarketingModule.Data.Model;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+namespace VirtoCommerce.MarketingModule.Data.PostgreSql;
+
+public class DynamicContentItemEntityConfiguration : IEntityTypeConfiguration<DynamicContentItemEntity>
+{
+    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<DynamicContentItemEntity> builder)
+    {
+        // Configure the entity here
+        builder.Property(x => x.Name).UseCaseInsensitiveCollation();
+    }
+}

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/DynamicContentPlaceEntityConfiguration.cs
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/DynamicContentPlaceEntityConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.MarketingModule.Data.Model;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+namespace VirtoCommerce.MarketingModule.Data.PostgreSql;
+
+public class DynamicContentPlaceEntityConfiguration : IEntityTypeConfiguration<DynamicContentPlaceEntity>
+{
+    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<DynamicContentPlaceEntity> builder)
+    {
+        // Configure the entity here
+        builder.Property(x => x.Name).UseCaseInsensitiveCollation();
+    }
+}

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/DynamicContentPublishingGroupEntityConfiguration.cs
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/DynamicContentPublishingGroupEntityConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.MarketingModule.Data.Model;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+namespace VirtoCommerce.MarketingModule.Data.PostgreSql;
+
+public class DynamicContentPublishingGroupEntityConfiguration : IEntityTypeConfiguration<DynamicContentPublishingGroupEntity>
+{
+    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<DynamicContentPublishingGroupEntity> builder)
+    {
+        // Configure the entity here
+        builder.Property(x => x.Name).UseCaseInsensitiveCollation();
+    }
+}

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/Migrations/20260413091644_AddCaseInsensitiveCollations.Designer.cs
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/Migrations/20260413091644_AddCaseInsensitiveCollations.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtoCommerce.MarketingModule.Data.Repositories;
@@ -11,9 +12,11 @@ using VirtoCommerce.MarketingModule.Data.Repositories;
 namespace VirtoCommerce.MarketingModule.Data.PostgreSql.Migrations
 {
     [DbContext(typeof(MarketingDbContext))]
-    partial class MarketingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413091644_AddCaseInsensitiveCollations")]
+    partial class AddCaseInsensitiveCollations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/Migrations/20260413091644_AddCaseInsensitiveCollations.cs
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/Migrations/20260413091644_AddCaseInsensitiveCollations.cs
@@ -1,0 +1,177 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+#nullable disable
+
+namespace VirtoCommerce.MarketingModule.Data.PostgreSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCaseInsensitiveCollations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateCaseInsensitiveCollationIfNotExists();
+
+            migrationBuilder.AlterColumn<string>(
+                name: "CouponCode",
+                table: "PromotionUsage",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Promotion",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "DynamicContentPublishingGroup",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "DynamicContentPlace",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "DynamicContentItem",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "DynamicContentFolder",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Code",
+                table: "Coupon",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "CouponCode",
+                table: "PromotionUsage",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldNullable: true,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Promotion",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "DynamicContentPublishingGroup",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "DynamicContentPlace",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "DynamicContentItem",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "DynamicContentFolder",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128,
+                oldCollation: "case_insensitive");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Code",
+                table: "Coupon",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64,
+                oldCollation: "case_insensitive");
+        }
+    }
+}

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/PromotionEntityConfiguration.cs
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/PromotionEntityConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.MarketingModule.Data.Model;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+namespace VirtoCommerce.MarketingModule.Data.PostgreSql;
+
+public class PromotionEntityConfiguration : IEntityTypeConfiguration<PromotionEntity>
+{
+    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<PromotionEntity> builder)
+    {
+        // Configure the entity here
+        builder.Property(x => x.Name).UseCaseInsensitiveCollation();
+    }
+}

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/PromotionUsageEntityConfiguration.cs
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/PromotionUsageEntityConfiguration.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.MarketingModule.Data.Model;
+using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
+
+namespace VirtoCommerce.MarketingModule.Data.PostgreSql;
+
+public class PromotionUsageEntityConfiguration : IEntityTypeConfiguration<PromotionUsageEntity>
+{
+    public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<PromotionUsageEntity> builder)
+    {
+        // Configure the entity here
+        builder.Property(x => x.CouponCode).UseCaseInsensitiveCollation();
+    }
+}

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.5
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.5
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/VirtoCommerce.MarketingModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/VirtoCommerce.MarketingModule.Data.PostgreSql.csproj
@@ -6,12 +6,12 @@
     <noWarn>NU1903</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Data\VirtoCommerce.MarketingModule.Data.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.MarketingModule.Data.SqlServer/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.5
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.5
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.MarketingModule.Data.SqlServer/VirtoCommerce.MarketingModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.MarketingModule.Data.SqlServer/VirtoCommerce.MarketingModule.Data.SqlServer.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Data\VirtoCommerce.MarketingModule.Data.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Data/VirtoCommerce.MarketingModule.Data.csproj
+++ b/src/VirtoCommerce.MarketingModule.Data/VirtoCommerce.MarketingModule.Data.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1013.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1013.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Core\VirtoCommerce.MarketingModule.Core.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Web/Module.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Module.cs
@@ -34,7 +34,6 @@ using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.ExportImport;
-using VirtoCommerce.Platform.Core.Extensions;
 using VirtoCommerce.Platform.Core.JsonConverters;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Security;
@@ -43,17 +42,17 @@ using VirtoCommerce.Platform.Data.Extensions;
 using VirtoCommerce.Platform.Data.MySql.Extensions;
 using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
 using VirtoCommerce.Platform.Data.SqlServer.Extensions;
+using VirtoCommerce.Platform.Modules;
 
 namespace VirtoCommerce.MarketingModule.Web
 {
     [ExcludeFromCodeCoverage]
-    public class Module : IModule, IExportSupport, IImportSupport, IHasConfiguration, IHasModuleCatalog
+    public class Module : IModule, IExportSupport, IImportSupport, IHasConfiguration
     {
         private IApplicationBuilder _appBuilder;
 
         public ManifestModuleInfo ModuleInfo { get; set; }
         public IConfiguration Configuration { get; set; }
-        public IModuleCatalog ModuleCatalog { get; set; }
 
         private const string _ordersModuleId = "VirtoCommerce.Orders";
 
@@ -135,7 +134,7 @@ namespace VirtoCommerce.MarketingModule.Web
             serviceCollection.AddTransient<LogChangesChangedEventHandler>();
             serviceCollection.AddTransient<MarketingExportImport>();
 
-            if (ModuleCatalog.IsModuleInstalled(_ordersModuleId))
+            if (ModuleBootstrapper.Instance.IsInstalled(_ordersModuleId))
             {
                 serviceCollection.AddTransient<CouponUsageRecordHandler>();
             }
@@ -168,7 +167,7 @@ namespace VirtoCommerce.MarketingModule.Web
             });
 
             //Create order observer. record order coupon usage
-            if (ModuleCatalog.IsModuleInstalled(_ordersModuleId))
+            if (ModuleBootstrapper.Instance.IsInstalled(_ordersModuleId))
             {
                 appBuilder.RegisterEventHandler<OrderChangedEvent, CouponUsageRecordHandler>();
             }

--- a/src/VirtoCommerce.MarketingModule.Web/VirtoCommerce.MarketingModule.Web.csproj
+++ b/src/VirtoCommerce.MarketingModule.Web/VirtoCommerce.MarketingModule.Web.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <noWarn>1591;NU1608</noWarn>
+    <noWarn>1591</noWarn>
     <OutputType>Library</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Core\VirtoCommerce.MarketingModule.Core.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Web/module.manifest
+++ b/src/VirtoCommerce.MarketingModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1003.0</version>
   <version-tag />
 
-  <platformVersion>3.1013.0</platformVersion>
+  <platformVersion>3.1016.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />

--- a/src/VirtoCommerce.MarketingModule.Web/package-lock.json
+++ b/src/VirtoCommerce.MarketingModule.Web/package-lock.json
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/VirtoCommerce.MarketingModule.Test/VirtoCommerce.MarketingModule.Test.csproj
+++ b/tests/VirtoCommerce.MarketingModule.Test/VirtoCommerce.MarketingModule.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <noWarn>1591;NU1608</noWarn>
+    <noWarn>1591</noWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4">


### PR DESCRIPTION
## Description
feat: Case Insensitive Search for PostgreSQL

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4902
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Marketing_3.1003.0-pr-263-5633.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a PostgreSQL migration that alters multiple string columns to use a case-insensitive collation, which can affect query semantics and index behavior during/after deployment. Also bumps VirtoCommerce platform/EF tooling dependencies and changes module-install detection to `ModuleBootstrapper`, which could impact optional Orders-module wiring.
> 
> **Overview**
> Enables **case-insensitive search/uniqueness behavior on PostgreSQL** by applying `UseCaseInsensitiveCollation()` to key Marketing entities and adding a new EF migration (`AddCaseInsensitiveCollations`) that creates the `case_insensitive` collation and alters relevant columns (e.g., coupon codes, promotion names, dynamic content names).
> 
> Updates module dependencies to platform `3.1016.0` (and EF design/tools to `10.0.5`), adjusts `module.manifest` platform requirement, and switches Orders-module presence checks in `Module.cs` from `IModuleCatalog` to `ModuleBootstrapper.Instance.IsInstalled()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5633c9b6983266e463c84ece235dc31e28b87239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->