### PR TITLE
VCST-5163: Stable 15 — Marketing (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
+++ b/src/VirtoCommerce.MarketingModule.Core/VirtoCommerce.MarketingModule.Core.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.MarketingModule.Data.MySql/VirtoCommerce.MarketingModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.MarketingModule.Data.MySql/VirtoCommerce.MarketingModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Data\VirtoCommerce.MarketingModule.Data.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Data.PostgreSql/VirtoCommerce.MarketingModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.MarketingModule.Data.PostgreSql/VirtoCommerce.MarketingModule.Data.PostgreSql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Data\VirtoCommerce.MarketingModule.Data.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Data.SqlServer/VirtoCommerce.MarketingModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.MarketingModule.Data.SqlServer/VirtoCommerce.MarketingModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Data\VirtoCommerce.MarketingModule.Data.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Data/ExportImport/MarketingExportImport.cs
+++ b/src/VirtoCommerce.MarketingModule.Data/ExportImport/MarketingExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -37,7 +38,7 @@ public class MarketingExportImport(
         Stream outputStream,
         ExportImportOptions options,
         Action<ExportImportProgressInfo> progressCallback,
-        ICancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var progressInfo = new ExportImportProgressInfo { Description = "loading data..." };
@@ -179,7 +180,7 @@ public class MarketingExportImport(
         Stream inputStream,
         ExportImportOptions options,
         Action<ExportImportProgressInfo> progressCallback,
-        ICancellationToken cancellationToken)
+        CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.MarketingModule.Data/ExportImport/MarketingExportImport.cs
+++ b/src/VirtoCommerce.MarketingModule.Data/ExportImport/MarketingExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.Collections.Generic;
 using System.IO;
@@ -46,12 +47,12 @@ public class MarketingExportImport(
 
         await using var streamWriter = new StreamWriter(outputStream);
         await using var writer = new JsonTextWriter(streamWriter);
-        await writer.WriteStartObjectAsync();
+        await writer.WriteStartObjectAsync(cancellationToken);
 
         progressInfo.Description = "Promotions exporting...";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("Promotions");
+        await writer.WritePropertyNameAsync("Promotions", cancellationToken);
 
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, _batchSize, async (skip, take) =>
             (GenericSearchResult<Promotion>)await LoadPromotionsPageAsync(skip, take, options, progressCallback),
@@ -65,7 +66,7 @@ public class MarketingExportImport(
         progressInfo.Description = "Dynamic content folders exporting...";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("DynamicContentFolders");
+        await writer.WritePropertyNameAsync("DynamicContentFolders", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, _batchSize, async (_, _) =>
             {
                 var searchResult = AbstractTypeFactory<DynamicContentFolderSearchResult>.TryCreateInstance();
@@ -84,7 +85,7 @@ public class MarketingExportImport(
         progressInfo.Description = "Dynamic content items exporting...";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("DynamicContentItems");
+        await writer.WritePropertyNameAsync("DynamicContentItems", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, _batchSize, async (skip, take) =>
             {
                 var searchCriteria = AbstractTypeFactory<DynamicContentItemSearchCriteria>.TryCreateInstance();
@@ -102,7 +103,7 @@ public class MarketingExportImport(
         progressInfo.Description = "Dynamic content places exporting...";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("DynamicContentPlaces");
+        await writer.WritePropertyNameAsync("DynamicContentPlaces", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, _batchSize, async (skip, take) =>
             {
                 var searchCriteria = AbstractTypeFactory<DynamicContentPlaceSearchCriteria>.TryCreateInstance();
@@ -120,7 +121,7 @@ public class MarketingExportImport(
         progressInfo.Description = "Dynamic content publications exporting...";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("DynamicContentPublications");
+        await writer.WritePropertyNameAsync("DynamicContentPublications", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, _batchSize, async (skip, take) =>
             {
                 var searchCriteria = AbstractTypeFactory<DynamicContentPublicationSearchCriteria>.TryCreateInstance();
@@ -139,7 +140,7 @@ public class MarketingExportImport(
         progressInfo.Description = "Coupons exporting...";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("Coupons");
+        await writer.WritePropertyNameAsync("Coupons", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, _batchSize, async (skip, take) =>
             {
                 var searchCriteria = AbstractTypeFactory<CouponSearchCriteria>.TryCreateInstance();
@@ -157,7 +158,7 @@ public class MarketingExportImport(
         progressInfo.Description = "Usages exporting...";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("Usages");
+        await writer.WritePropertyNameAsync("Usages", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, _batchSize, async (skip, take) =>
             {
                 var searchCriteria = AbstractTypeFactory<PromotionUsageSearchCriteria>.TryCreateInstance();
@@ -172,8 +173,8 @@ public class MarketingExportImport(
             },
             cancellationToken);
 
-        await writer.WriteEndObjectAsync();
-        await writer.FlushAsync();
+        await writer.WriteEndObjectAsync(cancellationToken);
+        await writer.FlushAsync(cancellationToken);
     }
 
     public virtual async Task DoImportAsync(
@@ -189,7 +190,7 @@ public class MarketingExportImport(
         using var streamReader = new StreamReader(inputStream);
         await using var reader = new JsonTextReader(streamReader);
 
-        while (await reader.ReadAsync())
+        while (await reader.ReadAsync(cancellationToken))
         {
             if (reader.TokenType == JsonToken.PropertyName)
             {

--- a/src/VirtoCommerce.MarketingModule.Data/VirtoCommerce.MarketingModule.Data.csproj
+++ b/src/VirtoCommerce.MarketingModule.Data/VirtoCommerce.MarketingModule.Data.csproj
@@ -12,10 +12,10 @@
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="33.1.0" />
     
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1009.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Core\VirtoCommerce.MarketingModule.Core.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Web/Module.cs
+++ b/src/VirtoCommerce.MarketingModule.Web/Module.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -42,17 +43,17 @@ using VirtoCommerce.Platform.Data.Extensions;
 using VirtoCommerce.Platform.Data.MySql.Extensions;
 using VirtoCommerce.Platform.Data.PostgreSql.Extensions;
 using VirtoCommerce.Platform.Data.SqlServer.Extensions;
-using VirtoCommerce.Platform.Modules;
 
 namespace VirtoCommerce.MarketingModule.Web
 {
     [ExcludeFromCodeCoverage]
-    public class Module : IModule, IExportSupport, IImportSupport, IHasConfiguration
+    public class Module : IModule, IExportSupport, IImportSupport, IHasConfiguration, IHasModuleService
     {
         private IApplicationBuilder _appBuilder;
 
         public ManifestModuleInfo ModuleInfo { get; set; }
         public IConfiguration Configuration { get; set; }
+        public IModuleService ModuleService { get; set; }
 
         private const string _ordersModuleId = "VirtoCommerce.Orders";
 
@@ -134,7 +135,7 @@ namespace VirtoCommerce.MarketingModule.Web
             serviceCollection.AddTransient<LogChangesChangedEventHandler>();
             serviceCollection.AddTransient<MarketingExportImport>();
 
-            if (ModuleBootstrapper.Instance.IsInstalled(_ordersModuleId))
+            if (ModuleService.IsInstalled(_ordersModuleId))
             {
                 serviceCollection.AddTransient<CouponUsageRecordHandler>();
             }
@@ -167,7 +168,7 @@ namespace VirtoCommerce.MarketingModule.Web
             });
 
             //Create order observer. record order coupon usage
-            if (ModuleBootstrapper.Instance.IsInstalled(_ordersModuleId))
+            if (ModuleService.IsInstalled(_ordersModuleId))
             {
                 appBuilder.RegisterEventHandler<OrderChangedEvent, CouponUsageRecordHandler>();
             }
@@ -233,12 +234,12 @@ namespace VirtoCommerce.MarketingModule.Web
             // Method intentionally left empty.
         }
 
-        public Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             return _appBuilder.ApplicationServices.GetRequiredService<MarketingExportImport>().DoExportAsync(outStream, options, progressCallback, cancellationToken);
         }
 
-        public Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             return _appBuilder.ApplicationServices.GetRequiredService<MarketingExportImport>().DoImportAsync(inputStream, options, progressCallback, cancellationToken);
         }

--- a/src/VirtoCommerce.MarketingModule.Web/VirtoCommerce.MarketingModule.Web.csproj
+++ b/src/VirtoCommerce.MarketingModule.Web/VirtoCommerce.MarketingModule.Web.csproj
@@ -15,8 +15,8 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Modules" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.MarketingModule.Core\VirtoCommerce.MarketingModule.Core.csproj" />

--- a/src/VirtoCommerce.MarketingModule.Web/module.manifest
+++ b/src/VirtoCommerce.MarketingModule.Web/module.manifest
@@ -4,16 +4,16 @@
   <version>3.1005.0</version>
   <version-tag />
 
-  <platformVersion>3.1016.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.Orders" version="3.1000.0" optional="true" />
-    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Shipping" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1011.0" optional="true" />
+    <dependency id="VirtoCommerce.Orders" version="3.1009.0" optional="true" />
+    <dependency id="VirtoCommerce.Payment" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Shipping" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
 
   <title>Marketing</title>

--- a/src/VirtoCommerce.MarketingModule.Web/package-lock.json
+++ b/src/VirtoCommerce.MarketingModule.Web/package-lock.json
@@ -855,9 +855,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1627,9 +1627,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1647,7 +1647,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/tests/VirtoCommerce.MarketingModule.Test/VirtoCommerce.MarketingModule.Test.csproj
+++ b/tests/VirtoCommerce.MarketingModule.Test/VirtoCommerce.MarketingModule.Test.csproj
@@ -4,7 +4,7 @@
     <noWarn>1591</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -15,7 +15,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     
     
-    <PackageReference Include="VirtoCommerce.Testing" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Testing" Version="3.1039.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.v3.runner.console" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tests/VirtoCommerce.MarketingModule.Test/VirtoCommerce.MarketingModule.Tests.csproj
+++ b/tests/VirtoCommerce.MarketingModule.Test/VirtoCommerce.MarketingModule.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Moq" Version="4.20.72" />
     
     
-    <PackageReference Include="VirtoCommerce.Testing" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Testing" Version="3.1039.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.v3.runner.console" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Part of **Stable 15** (Wave 7). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Waves 1–6 packages on nuget.org. Version handled by CI.

- Removed obsolete members per VC0012 policy; ICT migration; Customer dep 3.1011.0.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches marketing export/import and module bootstrap paths used for long-running jobs and optional Orders hooks; changes are mechanical platform migration but warrant regression on import/export cancel behavior.
> 
> **Overview**
> **Stable 15** alignment: bumps **VirtoCommerce platform** and related module packages to **3.1039.0** (and matching dependency versions in `module.manifest`), plus minor test/dev lockfile updates.
> 
> Adapts to platform API changes: export/import now uses **`CancellationToken`** instead of **`ICancellationToken`**, and **`MarketingExportImport`** passes the token through **Newtonsoft `JsonTextWriter`** async calls (including import **`ReadAsync`**). **`Module`** implements **`IHasModuleService`** and checks optional **Orders** integration via **`ModuleService.IsInstalled`** instead of **`ModuleBootstrapper`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee4f69f9995e1ed7c5eb274e30397231ef7eff2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Marketing_3.1005.0-pr-269-ee4f.zip